### PR TITLE
acached_per_instance: fix for non-hashable instances

### DIFF
--- a/asynq/tests/test_tools.py
+++ b/asynq/tests/test_tools.py
@@ -148,18 +148,31 @@ class AsyncObject(object):
         AsyncObject.cls_value += val
 
 
-def test_acached_per_instance():
-    obj = AsyncObject()
-    assert_eq(1, obj.get_value(0))
-    assert_eq(1, obj.get_value(0))
-    assert_eq(2, obj.get_value(1))
-    assert_eq(1, obj.get_value(0))
-    assert_eq(1, obj.get_value(index=0))
-    assert_eq(1, obj.get_value.async(index=0).value())
+class UnhashableAcached(AsyncObject):
+    __hash__ = None
 
-    assert_eq(8, obj.with_kwargs())
-    assert_eq(8, obj.with_kwargs(z=3))
-    assert_eq(17, obj.with_kwargs(x=3, y=3))
+
+def test_acached_per_instance():
+    for cls in (AsyncObject, UnhashableAcached):
+        obj = cls()
+        cache = type(obj).get_value.decorator.__acached_per_instance_cache__
+        assert_eq(0, len(cache), extra=repr(cache))
+
+        assert_eq(1, obj.get_value(0))
+        assert_eq(1, obj.get_value(0))
+        assert_eq(2, obj.get_value(1))
+        assert_eq(1, obj.get_value(0))
+        assert_eq(1, obj.get_value(index=0))
+        assert_eq(1, obj.get_value.async(index=0).value())
+
+        assert_eq(8, obj.with_kwargs())
+        assert_eq(8, obj.with_kwargs(z=3))
+        assert_eq(17, obj.with_kwargs(x=3, y=3))
+
+        assert_eq(1, len(cache), extra=repr(cache))
+
+        del obj
+        assert_eq(0, len(cache), extra=repr(cache))
 
 
 class Ctx(AsyncContext):


### PR DESCRIPTION
This fixes a regression introduced by #17. The new test uses `acached_per_instance` on a non-hashable class.

I also added a test that explicitly checks that an instance's cache is cleared up after the instance is GCed.