### PR TITLE
Support profiling for asynq tasks.

### DIFF
--- a/asynq/__init__.py
+++ b/asynq/__init__.py
@@ -31,6 +31,7 @@ from . import utils
 from . import contexts
 from . import scoped_value
 from . import tools
+from . import profiler
 from .futures import FutureBase, Future, FutureIsAlreadyComputed, none_future, ConstFuture, \
     ErrorFuture
 from .batching import BatchBase, BatchItemBase, BatchingError, BatchCancelledError

--- a/asynq/_debug.pxd
+++ b/asynq/_debug.pxd
@@ -32,6 +32,7 @@ cdef class DebugOptions(object):
     cdef public bint DUMP_STACK
     cdef public bint DUMP_SCHEDULER_STATE
     cdef public bint DUMP_SYNC_CALLS
+    cdef public bint COLLECT_PERF_STATS
 
     cdef public float SCHEDULER_STATE_DUMP_INTERVAL
     cdef public int DEBUG_STR_REPR_MAX_LENGTH

--- a/asynq/_debug.py
+++ b/asynq/_debug.py
@@ -41,6 +41,7 @@ class DebugOptions(object):
         self.DUMP_STACK            = False  # When it's meaningful, e.g. on batch flush
         self.DUMP_SCHEDULER_STATE  = False
         self.DUMP_SYNC_CALLS       = False
+        self.COLLECT_PERF_STATS    = False
 
         self.SCHEDULER_STATE_DUMP_INTERVAL = 1     # In seconds
         self.DEBUG_STR_REPR_MAX_LENGTH     = 240   # In characters, 0 means infinity

--- a/asynq/async_task.pxd
+++ b/asynq/async_task.pxd
@@ -21,6 +21,7 @@ cimport qcore.inspection as core_inspection
 cimport futures
 cimport scheduler
 cimport _debug
+cimport profiler
 
 
 cdef _debug.DebugOptions _debug_options
@@ -33,21 +34,25 @@ cdef class AsyncTask(futures.FutureBase):
     cdef public object fn
     cdef public object args
     cdef public object kwargs
+    cdef public str _name
     cdef public AsyncTask caller
     cdef public AsyncTask creator
     cdef public object _generator
     cdef public object _last_value
     cdef public object _frame
+    cdef public object perf_stats
     cdef public list _dependencies
     cdef public list _contexts
     cdef public bint _contexts_active
     cdef public bint _dependencies_scheduled
+    cdef public int _total_time
 
     cdef bint is_blocked(self) except -1
     cdef bint can_continue(self) except -1
 
     cpdef _compute(self)
     cpdef _computed(self)
+    cpdef dump_perf_stats(self)
 
     cdef _continue(self)
     cdef inline object _continue_on_generator(self, value, error)

--- a/asynq/async_task.pxd
+++ b/asynq/async_task.pxd
@@ -53,6 +53,8 @@ cdef class AsyncTask(futures.FutureBase):
     cpdef _compute(self)
     cpdef _computed(self)
     cpdef dump_perf_stats(self)
+    cpdef collect_perf_stats(self)
+    cpdef to_str(self)
 
     cdef _continue(self)
     cdef inline object _continue_on_generator(self, value, error)

--- a/asynq/debug.py
+++ b/asynq/debug.py
@@ -42,6 +42,7 @@ options.DUMP_SYNC             = False
 options.DUMP_STACK            = False  # When it's meaningful, e.g. on batch flush
 options.DUMP_SCHEDULER_STATE  = False
 options.DUMP_SYNC_CALLS       = False
+options.COLLECT_PERF_STATS    = False
 
 options.SCHEDULER_STATE_DUMP_INTERVAL = 1       # In seconds
 options.DEBUG_STR_REPR_MAX_LENGTH     = 240     # In characters, 0 means infinity

--- a/asynq/profiler.pxd
+++ b/asynq/profiler.pxd
@@ -1,0 +1,8 @@
+import cython
+
+cdef object _stats
+
+@cython.locals(out=list)
+cpdef flush()
+cpdef append(object stats)
+cpdef reset()

--- a/asynq/profiler.pxd
+++ b/asynq/profiler.pxd
@@ -1,6 +1,6 @@
 import cython
 
-cdef object _stats
+cdef object _state
 
 @cython.locals(out=list)
 cpdef flush()

--- a/asynq/profiler.py
+++ b/asynq/profiler.py
@@ -1,0 +1,25 @@
+import threading
+
+
+class LocalProfileState(threading.local):
+    def __init__(self):
+        super(LocalProfileState, self).__init__()
+        self.stats = []
+
+
+_state = LocalProfileState()
+globals()['_state'] = _state
+
+
+def flush():
+    out = _state.stats[:]
+    _state.stats[:] = []
+    return out
+
+
+def append(stats):
+    _state.stats.append(stats)
+
+
+def reset():
+    _state.stats[:] = []

--- a/asynq/scheduler.py
+++ b/asynq/scheduler.py
@@ -16,6 +16,7 @@ from sys import stderr, stdout
 import time
 import threading
 
+from qcore import utime
 import qcore.events as core_events
 
 
@@ -169,7 +170,14 @@ class TaskScheduler(object):
 
         if _debug_options.DUMP_CONTINUE_TASK:
             debug.write('@async: -> continuing %s' % debug.str(task))
-        task._continue()
+        if _debug_options.COLLECT_PERF_STATS:
+            start = utime()
+            task._continue()
+            task._total_time += utime() - start
+            if task.is_computed() and isinstance(task, AsyncTask):
+                task.dump_perf_stats()
+        else:
+            task._continue()
         if _debug_options.DUMP_CONTINUE_TASK:
             debug.write('@async: <- continued %s' % debug.str(task))
 
@@ -287,4 +295,3 @@ def get_active_task():
     global _state
     s = _state.current
     return None if s is None else s.active_task
-

--- a/asynq/tests/test_profiler.py
+++ b/asynq/tests/test_profiler.py
@@ -1,0 +1,93 @@
+import random
+import threading
+import time
+
+from qcore import SECOND
+from qcore.asserts import assert_eq, assert_le, assert_ge
+from asynq import asynq, debug, profiler, result
+from .debug_cache import reset_caches, mc
+from .caching import ExternalCacheBatchItem
+
+
+class ProfilerThread(threading.Thread):
+    def __init__(self, stats_list):
+        threading.Thread.__init__(self)
+        self.stats_list = stats_list
+
+    def run(self):
+        profiler.reset()
+        for stats in self.stats_list:
+            profiler.append(stats)
+        self.profiled_result = profiler.flush()
+
+
+def test_multithreaded_profiler():
+    """Test multithreaded profiler."""
+    stats_list = list(range(10000))
+
+    profiler.reset()
+    assert_eq([], profiler.flush())
+
+    threads = []
+    for i in range(30):
+        random.shuffle(stats_list)
+        thread = ProfilerThread(stats_list)
+        threads.append(thread)
+
+    random.shuffle(stats_list)
+    for stats in stats_list:
+        profiler.append(stats)
+
+    for thread in threads:
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+        assert_eq(thread.stats_list, thread.profiled_result)
+
+    assert_eq(stats_list, profiler.flush())
+
+
+def test_collect_perf_stats():
+    sleep_time = 50000  # 50ms
+
+    @asynq()
+    def func(depth):
+        if depth == 0:
+            result((yield ExternalCacheBatchItem(mc._batch, 'get', 'test'))); return
+        time.sleep(sleep_time / SECOND)
+        yield func.asynq(depth - 1), func.asynq(depth - 1)
+
+
+    debug.options.COLLECT_PERF_STATS = True
+    profiler.reset()
+    reset_caches()
+    depth = 3
+    func(depth)
+    profiled_result = profiler.flush()
+    assert_eq(2 ** (depth + 1) - 1, len(profiled_result))
+    for stats in profiled_result:
+        num_deps = stats['num_deps']
+        num_dependencies = len(stats['dependencies'])
+        time_taken = stats['time_taken']
+
+        # It has one ExternalCacheBatchItem, and no dependent AsyncTasks.
+        if num_deps == 1:
+            assert_eq(0, num_dependencies)
+            assert_ge(sleep_time, time_taken)
+
+        # It has two dependent AsyncTasks, and is sleeping for sleep_time (50ms).
+        elif num_deps == 2:
+            assert_eq(2, num_dependencies)
+            assert_le(sleep_time, time_taken)
+            assert_ge(sleep_time * 2, time_taken)
+        else:
+            assert False
+
+    # When COLLET_PERF_STATS is False, we shouldn't profile anything.
+    debug.options.COLLECT_PERF_STATS = False
+    profiler.reset()
+    reset_caches()
+    func(2)
+    profiled_result = profiler.flush()
+    assert_eq(0, len(profiled_result))

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ CYTHON_MODULES = [
     '_debug',
     'decorators',
     'futures',
+    'profiler',
     'scheduler',
     'scoped_value',
     'utils',


### PR DESCRIPTION
Python's standard profiling functions are not working well with AsyncTask as Asynq scheduler controls the tasks and therefore their stack traces are different from original function calls. 

To provide a way to find hotspots in async tasks, we added this performance profiling mode.