### PR TITLE
async_call: support functions with .async

### DIFF
--- a/asynq/decorators.py
+++ b/asynq/decorators.py
@@ -267,9 +267,12 @@ def async_call(fn, *args, **kwargs):
     """
     if is_pure_async_fn(fn):
         return fn(*args, **kwargs)
-    if is_async_fn(fn):
+    elif hasattr(fn, 'asynq'):
         return fn.asynq(*args, **kwargs)
-    return futures.ConstFuture(fn(*args, **kwargs))
+    elif hasattr(fn, 'async'):
+        return getattr(fn, 'async')(*args, **kwargs)
+    else:
+        return futures.ConstFuture(fn(*args, **kwargs))
 
 
 class AsyncWrapper(qcore.decorators.DecoratorBase):


### PR DESCRIPTION
Without this change, using async_call on functions that define
.async but not .asynq would throw an AttributeError.