### PR TITLE
asynq/continue_with_task: let exceptions be propogated

### DIFF
--- a/asynq/scheduler.pxd
+++ b/asynq/scheduler.pxd
@@ -43,7 +43,7 @@ cdef class TaskScheduler(object):
     cdef int _flush_batch(self, batching.BatchBase batch) except -1
 
     cdef _handle_async_task(self, async_task.AsyncTask task)
-    cdef int _continue_with_task(self, async_task.AsyncTask task)
+    cdef int _continue_with_task(self, async_task.AsyncTask task) except -1
     cdef batching.BatchBase _continue_with_batch(self)
     cdef batching.BatchBase _select_batch_to_flush(self)
 


### PR DESCRIPTION
this should allow memoryerrors to surface to the caller.