### PR TITLE
fix pickling of ConstFuture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.6"
 
 install:
+  - pip install --upgrade setuptools  # work around https://github.com/pypa/setuptools/issues/1086
   - pip install -r requirements.txt
   - pip install qcore
   - make install

--- a/asynq/futures.pxd
+++ b/asynq/futures.pxd
@@ -23,6 +23,7 @@ cdef _debug.DebugOptions _debug_options
 cdef core_helpers.MarkerObject _none
 
 
+@cython.auto_pickle(False)
 cdef class FutureBase(object):
     cdef public object _value
     cdef public object _error
@@ -45,13 +46,16 @@ cdef class FutureBase(object):
     cpdef dump(self, int indent=?)
 
 
+@cython.auto_pickle(False)
 cdef class Future(FutureBase):
     cdef public object _value_provider
     cpdef _compute(self)
 
 
+@cython.auto_pickle(False)
 cdef class ConstFuture(FutureBase):
     pass
 
+@cython.auto_pickle(False)
 cdef class ErrorFuture(FutureBase):
     pass

--- a/asynq/futures.py
+++ b/asynq/futures.py
@@ -199,15 +199,8 @@ class ConstFuture(FutureBase):
         self.set_value(value)
         self._in_repr = False  # since we don't call super.__init__
 
-    def __getstate__(self):
-        return self.value()
-
-    def __setstate__(self, state):
-        self._value = _none
-        self._error = None
-        self.on_computed = core_events.sinking_event_hook
-        self.set_value(state)
-        self._in_repr = False
+    def __reduce__(self):
+        return (ConstFuture, (self._value,))
 
 none_future = ConstFuture(None)
 
@@ -220,5 +213,3 @@ class ErrorFuture(FutureBase):
         self.on_computed = core_events.sinking_event_hook  # Simple performance optimization
         self.set_error(error)
         self._in_repr = False  # since we don't call super.__init__
-
-

--- a/asynq/tests/test_futures.py
+++ b/asynq/tests/test_futures.py
@@ -1,0 +1,11 @@
+import asynq
+import pickle
+from qcore.asserts import assert_eq
+
+
+def test_constfuture_pickling():
+    fut = asynq.ConstFuture(3)
+
+    for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+        pickled = pickle.dumps(fut, protocol)
+        assert_eq(fut.value(), pickle.loads(pickled).value())

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ Cython==0.26.0
 mock==2.0.0
 nose==1.3.7
 six==1.10.0
-setuptools==36.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cython==0.24.1
+Cython==0.26.1
 mock==2.0.0
 nose==1.3.7
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Cython==0.26.0
 mock==2.0.0
 nose==1.3.7
 six==1.10.0
+setuptools==36.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cython==0.26.1
+Cython==0.26.0
 mock==2.0.0
 nose==1.3.7
 six==1.10.0


### PR DESCRIPTION
In the most recent Cython version, the pickling behavior changed. This
PR adds tests for pickling and makes sure they work with the most
recent version of Cython.