### PR TITLE
Scheduler bug fix

### DIFF
--- a/asynq/scheduler.py
+++ b/asynq/scheduler.py
@@ -166,6 +166,7 @@ class TaskScheduler(object):
 
     def _continue_with_task(self, task):
         task._resume_contexts()
+        old_task = self.active_task
         self.active_task = task
 
         if _debug_options.DUMP_CONTINUE_TASK:
@@ -181,7 +182,7 @@ class TaskScheduler(object):
         if _debug_options.DUMP_CONTINUE_TASK:
             debug.write('@async: <- continued %s' % debug.str(task))
 
-        self.active_task = None
+        self.active_task = old_task
         # We get a new set of dependencies when we run _continue, so these haven't
         # been scheduled.
         task._dependencies_scheduled = False

--- a/asynq/tests/test_active_task.py
+++ b/asynq/tests/test_active_task.py
@@ -1,0 +1,41 @@
+# Copyright 2016 Quora, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from asynq import async, scheduler
+from qcore.asserts import assert_is, assert_is_not
+
+
+@async()
+def outer_async():
+    """Test that we get the correct active task from the scheduler.
+
+    Previously, there was a bug such that when we called a task synchronously from an async
+    function, the scheduler would lose track of the outer function after executing the inner
+    function, causing this test to fail.
+
+    """
+    assert_is_not(None, scheduler.get_active_task())
+    assert_is(outer_async.fn, scheduler.get_active_task().fn)
+    yield inner_async()
+    assert_is_not(None, scheduler.get_active_task())
+    assert_is(outer_async.fn, scheduler.get_active_task().fn)
+
+
+@async()
+def inner_async():
+    yield
+
+
+def test_active_task():
+    outer_async()

--- a/asynq/tests/test_active_task.py
+++ b/asynq/tests/test_active_task.py
@@ -13,23 +13,20 @@
 # limitations under the License.
 
 from asynq import async, scheduler
-from qcore.asserts import assert_is, assert_is_not
+from qcore.asserts import assert_is
 
 
 @async()
 def outer_async():
     """Test that we get the correct active task from the scheduler.
 
-    Previously, there was a bug such that when we called a task synchronously from an async
-    function, the scheduler would lose track of the outer function after executing the inner
-    function, causing this test to fail.
+    Even when the execution of one task gets interrupted by a synchonous call to another async
+    function, the scheduler retains the correct active task.
 
     """
-    assert_is_not(None, scheduler.get_active_task())
-    assert_is(outer_async.fn, scheduler.get_active_task().fn)
+    active_task = scheduler.get_active_task()
     inner_async()
-    assert_is_not(None, scheduler.get_active_task())
-    assert_is(outer_async.fn, scheduler.get_active_task().fn)
+    assert_is(active_task, scheduler.get_active_task())
 
 
 @async()

--- a/asynq/tests/test_active_task.py
+++ b/asynq/tests/test_active_task.py
@@ -27,14 +27,14 @@ def outer_async():
     """
     assert_is_not(None, scheduler.get_active_task())
     assert_is(outer_async.fn, scheduler.get_active_task().fn)
-    yield inner_async()
+    inner_async()
     assert_is_not(None, scheduler.get_active_task())
     assert_is(outer_async.fn, scheduler.get_active_task().fn)
 
 
 @async()
 def inner_async():
-    yield
+    pass
 
 
 def test_active_task():


### PR DESCRIPTION
Save old active task locally in case the global variable changes during execution of the task