### PR TITLE
Build wheels in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,25 @@
 language: python
 
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+sudo: required
+services:
+  - docker
+env:
+  global:
+    - DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+matrix:
+  include:
+    - python: "2.7"
+      env: PYVER=cp27-cp27m
+    - python: "3.4"
+      env: PYVER=cp34-cp34m
+    - python: "3.5"
+      env: PYVER=cp35-cp35m
+    - python: "3.6"
+      env: PYVER=cp36-cp36m
 
 install:
-  - pip install --upgrade setuptools  # work around https://github.com/pypa/setuptools/issues/1086
-  - pip install .
-  - pip install -r requirements.txt
+  - docker pull $DOCKER_IMAGE
 
-script: python -m nose asynq
+script:
+  - docker run --rm -e PYVER -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-wheels.sh
+  - ls wheelhouse/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       env: PYVER=cp35-cp35m
     - python: "3.6"
       env: PYVER=cp36-cp36m
+    - python: "3.7-dev"
+      env: PYVER=cp37-cp37m
 
 install:
   - docker pull $DOCKER_IMAGE

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 nose==1.3.7
 six==1.10.0
+mock; python_version < "3.3"
+Cython>=0.27.1
+qcore
+inspect2

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ if __name__ == '__main__':
 
             'Programming Language :: Python',
             'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ if __name__ == '__main__':
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
         ],
         keywords='quora asynq common utility',
         packages=['asynq', 'asynq.tests'],

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e -x
+
+PYBIN=/opt/python/$PYVER/bin
+
+"${PYBIN}/pip" install --upgrade setuptools  # work around https://github.com/pypa/setuptools/issues/1086
+
+# Compile wheels
+"${PYBIN}/pip" install -r /io/requirements.txt
+
+# Install dependencies of asynq
+"${PYBIN}/pip" install -U Cython qcore tox
+
+"${PYBIN}/pip" wheel /io/ -w wheelhouse/
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/*-$PYVER-*.whl; do
+    auditwheel repair "$whl" -w /io/wheelhouse/
+done
+
+# Copy plain wheels into the wheelhouse
+for whl in wheelhouse/*-py2.py3-*.whl; do
+    cp "$whl" /io/wheelhouse
+done
+
+# Install packages and test
+"${PYBIN}/pip" install asynq --no-index -f /io/wheelhouse
+(cd "$HOME"; "${PYBIN}/nosetests" asynq)

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -8,9 +8,6 @@ PYBIN=/opt/python/$PYVER/bin
 # Compile wheels
 "${PYBIN}/pip" install -r /io/requirements.txt
 
-# Install dependencies of asynq
-"${PYBIN}/pip" install -U Cython qcore tox
-
 "${PYBIN}/pip" wheel /io/ -w wheelhouse/
 
 # Bundle external shared libraries into the wheels


### PR DESCRIPTION
Per https://github.com/quora/asynq/issues/66, it'd be useful to provide pre-built wheels to users of this library.

I mostly copied from `python-manylinux-demo`: https://github.com/pypa/python-manylinux-demo/blob/master/travis/build-wheels.sh. This change makes it so that travis pulls the manylinux Docker image, builds and tests inside there, and then the built artifacts are available in a directory that is created in the current working directory (`/io/wheelhouse` in the Docker image, just `wheelhouse` from the perspective of Travis).

A notable change I did make was removing python 3.3 from the Travis build matrix because the manylinux Docker image does not support it. Is Python 3.3 support worth special casing it in the Travis environment?

Unlike Circle CI, which makes test artifacts readily available for download, it looks like we have to manually tell Travis to upload these things somewhere (https://docs.travis-ci.com/user/uploading-artifacts/). So the maintainers of this package would still need to figure out how they want to deploy these files.