### PR TITLE
fix deduplicate.async

### DIFF
--- a/asynq/tests/test_active_task.py
+++ b/asynq/tests/test_active_task.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from asynq import async, scheduler
+from asynq import asynq, scheduler
 from qcore.asserts import assert_is
 
 
-@async()
+@asynq()
 def outer_async():
     """Test that we get the correct active task from the scheduler.
 
@@ -29,7 +29,7 @@ def outer_async():
     assert_is(active_task, scheduler.get_active_task())
 
 
-@async()
+@asynq()
 def inner_async():
     pass
 

--- a/asynq/tests/test_tools.py
+++ b/asynq/tests/test_tools.py
@@ -214,13 +214,13 @@ def _check_alru_cache():
     def cube(n):
         return n * n * n
 
-    assert_eq(1, (yield cube.async(1)))
+    assert_eq(1, (yield cube.asynq(1)))
     # hit the cache
-    assert_eq(1, (yield cube.async(3)))
+    assert_eq(1, (yield cube.asynq(3)))
     # cache miss
-    assert_eq(8, (yield cube.async(2)))
+    assert_eq(8, (yield cube.asynq(2)))
     # now it's a cache miss
-    assert_eq(27, (yield cube.async(3)))
+    assert_eq(27, (yield cube.asynq(3)))
 
 
 class Ctx(AsyncContext):
@@ -314,12 +314,12 @@ def _check_deduplicate():
     i = 0
     yield recursive_call_with_dirty.asynq()
 
-    yield call_with_dirty.async()
+    yield call_with_dirty.asynq()
 
     if sys.version_info >= (3, 0):
         with AssertRaises(TypeError):
-            yield call_with_kwonly_arg.async(1)
-        assert_eq(1, (yield call_with_kwonly_arg.async(arg=1)))
+            yield call_with_kwonly_arg.asynq(1)
+        assert_eq(1, (yield call_with_kwonly_arg.asynq(arg=1)))
 
 
 def test_deduplicate_recursion():
@@ -421,7 +421,7 @@ class DeduplicateClassWrapper:
     @asynq()
     def return_three_and_five(self):
         result((yield (
-            self.return_three.async(), self.return_five.async()
+            self.return_three.asynq(), self.return_five.asynq()
         ))); return
 
 

--- a/asynq/tools.py
+++ b/asynq/tools.py
@@ -295,6 +295,8 @@ class DeduplicateDecorator(AsyncDecorator):
             task.on_computed.subscribe(callback)
             return task
 
+    locals()['async'] = asynq
+
     def dirty(self, *args, **kwargs):
         cache_key = self.cache_key(args, kwargs)
         self.tasks.pop(cache_key, None)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ CYTHON_MODULES = [
 DATA_FILES = ['%s.pxd' % module for module in CYTHON_MODULES]
 
 
-VERSION = '1.0.1'
+VERSION = '1.0.2'
 
 
 EXTENSIONS = [


### PR DESCRIPTION
While testing Python 3.7, I discovered that `deduplicate()` as currently written works only with `.asynq()`, not `.async()`.

This PR also fixes some usage of `.async` in tests to prepare for supporting 3.7. Before we can actually support 3.7, we need to fix some Cython issues though.