### PR TITLE
profiler: Support Batch and BatchItem(s)

### DIFF
--- a/asynq/async_task.pxd
+++ b/asynq/async_task.pxd
@@ -22,6 +22,7 @@ cimport futures
 cimport scheduler
 cimport _debug
 cimport profiler
+cimport batching
 
 
 cdef _debug.DebugOptions _debug_options
@@ -49,11 +50,11 @@ cdef class AsyncTask(futures.FutureBase):
 
     cdef bint is_blocked(self) except -1
     cdef bint can_continue(self) except -1
+    cdef dump_perf_stats(self)
+    cdef collect_perf_stats(self)
 
     cpdef _compute(self)
     cpdef _computed(self)
-    cpdef dump_perf_stats(self)
-    cpdef collect_perf_stats(self)
     cpdef to_str(self)
 
     cdef _continue(self)

--- a/asynq/async_task.py
+++ b/asynq/async_task.py
@@ -24,6 +24,7 @@ from . import debug
 from . import futures
 from . import profiler
 from . import _debug
+from . import batching
 
 import asynq
 
@@ -131,7 +132,8 @@ class AsyncTask(futures.FutureBase):
             'num_deps': len(self._dependencies),
             'dependencies': [
                 (t.to_str(), t._total_time)
-                for t in self._dependencies if isinstance(t, AsyncTask)
+                for t in self._dependencies
+                if (isinstance(t, AsyncTask) or isinstance(t, batching.BatchItemBase))
             ]
         }
 

--- a/asynq/async_task.py
+++ b/asynq/async_task.py
@@ -132,8 +132,7 @@ class AsyncTask(futures.FutureBase):
             'num_deps': len(self._dependencies),
             'dependencies': [
                 (t.to_str(), t._total_time)
-                for t in self._dependencies
-                if (isinstance(t, AsyncTask) or isinstance(t, batching.BatchItemBase))
+                for t in self._dependencies if isinstance(t, (AsyncTask, batching.BatchItemBase))
             ]
         }
 

--- a/asynq/batching.pxd
+++ b/asynq/batching.pxd
@@ -18,6 +18,7 @@ from cpython.ref cimport PyObject
 cimport qcore.inspection as core_inspection
 cimport futures
 cimport _debug
+cimport profiler
 
 
 cdef _debug.DebugOptions _debug_options
@@ -25,6 +26,9 @@ cdef _debug.DebugOptions _debug_options
 
 cdef class BatchBase(futures.FutureBase):
     cdef public list items
+    cdef public int _total_time
+    cdef public int _id
+    cdef dump_perf_stats(self, int time_taken)
 
     cpdef bint is_flushed(self) except -1
     cpdef bint is_cancelled(self) except -1
@@ -33,6 +37,7 @@ cdef class BatchBase(futures.FutureBase):
 
     cpdef flush(self)
     cpdef cancel(self, object error=?)
+    cpdef to_str(self)
 
     cpdef _compute(self)
     cpdef _computed(self)
@@ -45,9 +50,11 @@ cdef class BatchBase(futures.FutureBase):
 cdef class BatchItemBase(futures.FutureBase):
     cdef public BatchBase batch
     cdef public long index
+    cdef public int _total_time
+    cdef public int _id
 
     cpdef _compute(self)
-
+    cpdef to_str(self)
 
 cdef class DebugBatchItem(BatchItemBase):
     cdef public object _result

--- a/asynq/scheduler.py
+++ b/asynq/scheduler.py
@@ -126,7 +126,12 @@ class TaskScheduler(object):
     def _flush_batch(self, batch):
         self.on_before_batch_flush(batch)
         try:
-            batch.flush()
+            if _debug_options.COLLECT_PERF_STATS:
+                start = utime()
+                batch.flush()
+                batch.dump_perf_stats(utime() - start)
+            else:
+                batch.flush()
         finally:
             self.on_after_batch_flush(batch)
         return 0
@@ -175,7 +180,7 @@ class TaskScheduler(object):
             start = utime()
             task._continue()
             task._total_time += utime() - start
-            if task.is_computed() and isinstance(task, AsyncTask):
+            if task.is_computed():
                 task.dump_perf_stats()
         else:
             task._continue()


### PR DESCRIPTION
Previously, we only support AsyncTask information - this change makes Batch and BatchItems also report information to the profiler so that we can use it to get a more complete picture of the async call tree.