### PR TITLE
delete _active_task attribute on AsyncContexts

### DIFF
--- a/asynq/contexts.py
+++ b/asynq/contexts.py
@@ -78,6 +78,7 @@ class AsyncContext(object):
     def __exit__(self, ty, value, tb):
         leave_context(self, self._active_task)
         self.pause()
+        del self._active_task
 
     def resume(self):
         raise NotImplementedError()


### PR DESCRIPTION
Otherwise we risk leaving a stray reference around to the task, which could lead to memory leaks.