### PR TITLE
Add ability to access whether a task is running or not

### DIFF
--- a/asynq/async_task.pxd
+++ b/asynq/async_task.pxd
@@ -37,6 +37,7 @@ cdef class AsyncTask(futures.FutureBase):
     cdef public object kwargs
     cdef public str _name
     cdef public AsyncTask creator
+    cdef public bint running
     cdef public object _generator
     cdef public object _last_value
     cdef public object _frame


### PR DESCRIPTION
This commit adds a flag that captures whether a task is running or not. It mirrors asynq3 in this aspect.