### PR TITLE
drop Cython maximum version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 nose==1.3.7
-six==1.10.0
+six==1.15.0
 mock; python_version < "3.3"
-Cython>=0.27.1,<0.29.0
+Cython>=0.27.1
 qcore
 inspect2
 pygments

--- a/setup.py
+++ b/setup.py
@@ -79,9 +79,9 @@ if __name__ == '__main__':
         packages=['asynq', 'asynq.tests'],
         package_data={'asynq': DATA_FILES},
         ext_modules=EXTENSIONS,
-        setup_requires=['Cython>=0.27.1,<0.29.0', 'qcore', 'setuptools'],
+        setup_requires=['Cython>=0.27.1', 'qcore', 'setuptools'],
         install_requires=[
-            'Cython>=0.27.1,<0.29.0',
+            'Cython>=0.27.1',
             'qcore',
             'inspect2',
             'mock; python_version < "3.3"',

--- a/setup.py
+++ b/setup.py
@@ -70,10 +70,10 @@ if __name__ == '__main__':
 
             'Programming Language :: Python',
             'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
         ],
         keywords='quora asynq common utility',
         packages=['asynq', 'asynq.tests'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py34,py35,py36
+    py27,py35,py36,py37,py38
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Older versions of Cython don't work with Python 3.9.