### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/asynq/async_task.py
+++ b/asynq/async_task.py
@@ -271,7 +271,7 @@ class AsyncTask(futures.FutureBase):
                 # now, we are storing the _traceback on the error. we use this so we can
                 # raise it with that exact traceback later.
                 # now, we when do raise it, the upper level gets a new traceback
-                # with the curent level's traceback connected via a linked list pointer.
+                # with the current level's traceback connected via a linked list pointer.
                 # known as tb_next in traceback object.
                 # this is really important. if we keep updating this traceback,
                 # we can glue all the different tasks' tracebacks and make it look like

--- a/asynq/tests/test_active_task.py
+++ b/asynq/tests/test_active_task.py
@@ -20,7 +20,7 @@ from qcore.asserts import assert_is
 def outer_async():
     """Test that we get the correct active task from the scheduler.
 
-    Even when the execution of one task gets interrupted by a synchonous call to another async
+    Even when the execution of one task gets interrupted by a synchronous call to another async
     function, the scheduler retains the correct active task.
 
     """

--- a/asynq/tests/test_tools.py
+++ b/asynq/tests/test_tools.py
@@ -648,5 +648,5 @@ class DeduplicateClassWrapper:
 def test_deduplicate_same_class():
     obj = DeduplicateClassWrapper()
 
-    # make sure the five method has a seperate key and therefore there was no cache mixup
+    # make sure the five method has a separate key and therefore there was no cache mixup
     assert_eq((3, 5), obj.return_three_and_five())

--- a/asynq/tools.py
+++ b/asynq/tools.py
@@ -228,7 +228,7 @@ def acached_per_instance():
 def alru_cache(maxsize=128, key_fn=None):
     """Async equivalent of qcore.caching.lru_cache().
 
-    maxsize is the number of different keys cache can accomodate.
+    maxsize is the number of different keys cache can accommodate.
     key_fn is the function that builds key from args. The default key function
     creates a tuple out of args and kwargs. If you use the default it acts the same
     as functools.lru_cache (except with async).


### PR DESCRIPTION
There are small typos in:
- asynq/async_task.py
- asynq/tests/test_active_task.py
- asynq/tests/test_tools.py
- asynq/tools.py

Fixes:
- Should read `synchronous` rather than `synchonous`.
- Should read `separate` rather than `seperate`.
- Should read `current` rather than `curent`.
- Should read `accommodate` rather than `accomodate`.

Closes #105