### PR TITLE
modernize the codebase

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Unreleased
 * Fix generator support for afilter() and afilterfalse()
+* Drop support for Python 2.7, 3.4, and 3.5
+* Add support for Python 3.9
+* Build wheels using GitHub actions
 
 ## 1.3.0
 * Support Python 3.8

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Converted to use ``asynq``, this code would look like:
     def all_author_names(aids):
         uids = yield [author_of_answer.asynq(aid) for aid in aids]
         names = yield [name_of_user.asynq(uid) for uid in uids]
-        result(names); return
+        return names
 
 All ``author_of_answer`` calls will be combined into a single memcache request, as will all of the
 ``name_of_user`` calls.
@@ -64,12 +64,6 @@ Decorators and asynchronous functions
 asynchronous functions yields one or more Futures, it cedes control the asynq scheduler, which will
 resolve the futures that were yielded and continue running the function after the futures have been
 computed.
-
-Returning a value from an asynchronous function is hard in Python 2 because generators are not
-allowed to return a value. ``asynq`` provides the special ``result()`` function that can be used to
-return a value from an asynchronous function; it is implemented by raising a custom exception
-that is caught by the scheduler. At Quora, we instead use a patched Python 2 binary that does
-support returning a value from a generator.
 
 The framework requires usage of the ``@asynq()`` decorator on all asynchronous functions. This
 decorator wraps the generator function so that it can be called like a normal, synchronous function.
@@ -207,7 +201,7 @@ of these are in the ``asynq.tools`` module. These tools include:
 Compatibility
 -------------
 
-``asynq`` runs on Python 2.7 and Python 3.
+``asynq`` runs on Python 3.6 and newer.
 
 Previous versions of ``asynq`` used the name ``async`` for the ``@asynq()`` decorator and the
 ``.asynq`` attribute. Because ``async`` is a keyword in recent versions of Python 3, we now use

--- a/asynq/__init__.py
+++ b/asynq/__init__.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__doc__ = """
+"""
 
 Asynq is a framework for asynchronous programming in Python.
 
 It supports futures, batching, and asynchronous contexts.
 
 """
-import sys
 
 from . import debug
 from . import futures

--- a/asynq/async_task.py
+++ b/asynq/async_task.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import inspect
-import six
 import sys
 
 import qcore.helpers as core_helpers
@@ -57,7 +56,7 @@ class AsyncTask(futures.FutureBase):
     """
 
     def __init__(self, generator, fn, args, kwargs):
-        super(AsyncTask, self).__init__()
+        super().__init__()
         if _debug_options.ENABLE_COMPLEX_ASSERTIONS:
             assert core_inspection.is_cython_or_generator(generator), (
                 "generator is expected, but %s is provided" % generator
@@ -463,7 +462,7 @@ def unwrap(value):
         return [unwrap(item) for item in lst]
     elif type(value) is dict:
         dct = value
-        return {key: unwrap(value) for key, value in six.iteritems(dct)}
+        return {key: unwrap(value) for key, value in dct.items()}
     else:
         raise TypeError(
             "Cannot unwrap an object of type '%s': only futures and None are allowed."
@@ -492,6 +491,6 @@ def extract_futures(value, result):
             extract_futures(value[i], result)
             i -= 1
     elif type(value) is dict:
-        for item in six.itervalues(value):
+        for item in value.values():
             extract_futures(item, result)
     return result

--- a/asynq/debug.py
+++ b/asynq/debug.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import contextlib
 import sys
 import qcore
@@ -341,9 +340,10 @@ def disable_complex_assertions():
 
 
 def sync():
-    assert (
-        False
-    ), "'import asynq' seems broken: this function must be replaced with asynq.batching.sync."
+    assert False, (
+        "'import asynq' seems broken: this function must be replaced with"
+        " asynq.batching.sync."
+    )
 
 
 def get_frame(generator):

--- a/asynq/decorators.pyi
+++ b/asynq/decorators.pyi
@@ -87,14 +87,14 @@ def asynq(  # type: ignore
     *,
     sync_fn: Optional[Callable[..., Any]] = ...,
     cls: Type[futures.FutureBase] = ...,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> _MkAsyncDecorator: ...
 @overload
 def asynq(
     pure: bool,
     sync_fn: Optional[Callable[..., Any]] = ...,
     cls: Type[futures.FutureBase] = ...,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> _MkPureAsyncDecorator: ...  # type: ignore
 @overload
 def async_proxy(
@@ -108,7 +108,7 @@ def async_proxy(
 def async_call(
     fn: Union[Callable[..., _T], Callable[..., futures.FutureBase[_T]]],
     *args: Any,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> _T: ...
 def make_async_decorator(
     fn: Callable[..., Any],

--- a/asynq/futures.py
+++ b/asynq/futures.py
@@ -26,7 +26,7 @@ __traceback_hide__ = True
 
 
 _debug_options = _debug.options
-_none = core_helpers.MarkerObject(u"none (futures)")
+_none = core_helpers.MarkerObject("none (futures)")
 globals()["_none"] = _none
 
 

--- a/asynq/generator.py
+++ b/asynq/generator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__doc__ = """
+"""
 
 Async generators.
 
@@ -22,9 +22,8 @@ import functools
 
 from .decorators import asynq, async_proxy
 from .futures import ConstFuture
-from .utils import result
 
-END_OF_GENERATOR = qcore.MarkerObject(u"end of generator")
+END_OF_GENERATOR = qcore.MarkerObject("end of generator")
 
 
 def async_generator():
@@ -97,8 +96,7 @@ def list_of_generator(generator):
         if value is END_OF_GENERATOR:
             continue
         data.append(value)
-    result(data)
-    return
+    return data
 
 
 @asynq()
@@ -112,8 +110,7 @@ def take_first(generator, n):
         ret.append(value)
         if i == n - 1:
             break
-    result(ret)
-    return
+    return ret
 
 
 class _AsyncGenerator(object):
@@ -160,11 +157,9 @@ class _AsyncGenerator(object):
             try:
                 value = self._get_one_value(yield_result)
             except StopIteration:
-                result(END_OF_GENERATOR)
-                return
+                return END_OF_GENERATOR
             if isinstance(value, Value):
-                result(value.value)
-                return
+                return value.value
             else:
                 yield_result = yield value
 

--- a/asynq/mock_.py
+++ b/asynq/mock_.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__doc__ = """
+"""
 
 Easy mocking for async functions.
 
@@ -24,27 +24,13 @@ This file is named mock_ instead of mock so that it can import the standard mock
 """
 
 import inspect
-
-try:
-    from unittest import mock
-except ImportError:
-    # py3
-    import mock
-
-try:
-    _patch = mock._patch
-except AttributeError:
-    # some versions of mock put the implementation in mock/mock.py
-    _patch = mock.mock._patch
-try:
-    _get_target = mock._get_target
-except AttributeError:
-    # some versions of mock put the implementation in mock/mock.py
-    _get_target = mock.mock._get_target
-
+from unittest import mock
 
 from .decorators import asynq
 from .futures import ConstFuture
+
+_patch = mock._patch
+_get_target = mock._get_target
 
 
 def patch(
@@ -56,7 +42,7 @@ def patch(
     spec_set=None,
     autospec=False,
     new_callable=None,
-    **kwargs
+    **kwargs,
 ):
     """Mocks an async function.
 
@@ -90,7 +76,7 @@ def _patch_object(
     spec_set=None,
     autospec=False,
     new_callable=None,
-    **kwargs
+    **kwargs,
 ):
     getter = lambda: target
     return _make_patch_async(
@@ -220,8 +206,8 @@ class _AsyncWrapper(object):
 
     def __getattr__(self, attr):
         raise TypeError(
-            "You cannot read attributes directly on a .asynq function. Read them on the "
-            "function itself instead."
+            "You cannot read attributes directly on a .asynq function. Read them on the"
+            " function itself instead."
         )
 
 

--- a/asynq/scoped_value.py
+++ b/asynq/scoped_value.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__doc__ = """
+"""
 
 Helpers to use scoped values within async functions.
 

--- a/asynq/tests/test_batching.py
+++ b/asynq/tests/test_batching.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from asynq import asynq, result
+from asynq import asynq
 from .debug_cache import reset_caches, mc
 from .caching import ExternalCacheBatchItem
 
@@ -21,8 +21,7 @@ def test_chain():
     @asynq()
     def foo(num_yield):
         if num_yield == 0:
-            result(0)
-            return
+            return 0
 
         yield ExternalCacheBatchItem(mc._batch, "get", "test")
         yield foo.asynq(num_yield - 1)
@@ -36,8 +35,7 @@ def test_tree():
     @asynq()
     def foo(depth):
         if depth == 0:
-            result((yield ExternalCacheBatchItem(mc._batch, "get", "test")))
-            return
+            return (yield ExternalCacheBatchItem(mc._batch, "get", "test"))
         yield foo.asynq(depth - 1), foo.asynq(depth - 1)
 
     reset_caches()

--- a/asynq/tests/test_channels.py
+++ b/asynq/tests/test_channels.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 from qcore import MarkerObject
-from asynq import asynq, async_proxy, result, ConstFuture
+from asynq import asynq, async_proxy, ConstFuture
 from collections import deque
 
 
 # TODO(alex): finish w/this test
 
 
-empty = MarkerObject(u"empty @ asynq.channels")
+empty = MarkerObject("empty @ asynq.channels")
 future_empty = ConstFuture(empty)
 future_false = ConstFuture(False)
 future_true = ConstFuture(True)
@@ -55,8 +55,7 @@ def _push_async(channel, value):
     yield None
     while True:
         if channel.push(value, False) is future_true:
-            result(future_true)
-            return
+            return future_true
         yield None
 
 
@@ -66,6 +65,5 @@ def _pull_async(channel):
     while True:
         item = channel.pull(False)
         if item is not future_empty:
-            result(item)
-            return
+            return item
         yield None

--- a/asynq/tests/test_decorators.py
+++ b/asynq/tests/test_decorators.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from qcore.asserts import assert_eq, assert_is, assert_is_instance, AssertRaises
-from asynq import asynq, async_proxy, is_pure_async_fn, result, async_call, ConstFuture
+from asynq import asynq, async_proxy, is_pure_async_fn, async_call, ConstFuture
 from asynq.decorators import (
     lazy,
     get_async_fn,
@@ -28,8 +28,7 @@ def double_return_value(fun):
     @asynq(pure=True)
     def wrapper_fn(*args, **kwargs):
         value = yield fun.asynq(*args, **kwargs)
-        result(value * 2)
-        return
+        return value * 2
 
     return make_async_decorator(fun, wrapper_fn, "double_return_value")
 
@@ -57,8 +56,7 @@ class MyClass(object):
         cls, proxied = yield self.async_proxy_classmethod.asynq(number)
         assert cls is MyClass
         assert proxied == number
-        result(self)
-        return
+        return self
 
     @async_proxy()
     @classmethod
@@ -73,36 +71,31 @@ class MyClass(object):
         assert (yield cls.get_cls_ac.asynq()) is cls
         assert cls.get_cls().value() is cls
         assert (yield cls.get_cls()) is cls
-        result((cls, number))
-        return
+        return (cls, number)
 
     @asynq()
     @classmethod
     def get_cls_ac(cls):
         print("get_cls_ac")
-        result(cls)
-        return
+        return cls
 
     @asynq(pure=True)
     @classmethod
     def get_cls(cls):
         print("get_cls")
-        result(cls)
-        return
+        return cls
 
     @asynq()
     @staticmethod
     def static_ac(number):
         print("static_ac")
-        result(number)
-        return
+        return number
 
     @staticmethod
     @asynq(pure=True)
     def static(number):
         print("static")
-        result(number)
-        return
+        return number
 
     @staticmethod
     def sync_staticmethod():

--- a/asynq/tests/test_exceptions.py
+++ b/asynq/tests/test_exceptions.py
@@ -44,7 +44,7 @@ def test():
         try:
             yield tasks
             raise AssertionError()
-        except AssertionError:
+        except Exception:
             pass
         assert counter == 2
         assert tasks[0].value() == 1

--- a/asynq/tests/test_exceptions.py
+++ b/asynq/tests/test_exceptions.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from asynq import asynq, result, AsyncContext
+from asynq import asynq, AsyncContext
 from qcore.asserts import AssertRaises, assert_eq
 
 from .helpers import Profiler
@@ -34,8 +34,7 @@ def test():
         if must_throw:
             raise RuntimeError
         counter += 1
-        result(counter)
-        return
+        return counter
 
     @asynq(pure=True)
     def test():
@@ -45,7 +44,7 @@ def test():
         try:
             yield tasks
             raise AssertionError()
-        except:
+        except AssertionError:
             pass
         assert counter == 2
         assert tasks[0].value() == 1
@@ -97,8 +96,7 @@ def test_async_context():
                     # we need this to have a real dependency on an async task, otherwise
                     # it executes the whole function inline and the real problem is never tested
                     val = yield dependency.asynq()
-        result(val)
-        return
+        return val
 
     def check_contexts_released_properly(raise_in_pause, raise_in_resume):
         with AssertRaises(KeyboardInterrupt):

--- a/asynq/tests/test_mock.py
+++ b/asynq/tests/test_mock.py
@@ -28,8 +28,7 @@ def fn():
 @asynq.asynq()
 def async_caller():
     ret = yield fn.asynq()
-    asynq.result((ret, fn()))
-    return
+    return (ret, fn())
 
 
 def non_async_caller():
@@ -56,8 +55,7 @@ instance = Cls()
 @asynq.asynq()
 def class_method_async_caller():
     ret = yield Cls.async_classmethod.asynq()
-    asynq.result((ret, Cls.async_classmethod()))
-    return
+    return (ret, Cls.async_classmethod())
 
 
 def class_method_non_async_caller():
@@ -68,8 +66,7 @@ def class_method_non_async_caller():
 def method_async_caller():
     obj = Cls()
     ret = yield obj.async_method.asynq()
-    asynq.result((ret, obj.async_method()))
-    return
+    return (ret, obj.async_method())
 
 
 def method_non_async_caller():

--- a/asynq/tests/test_multiple_inheritance.py
+++ b/asynq/tests/test_multiple_inheritance.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__doc__ = """
+"""
 
 Tests that when using multiple inheritance, both parent classes' methods can be called.
 
@@ -20,7 +20,7 @@ See the implementation of DecoratorBase.__get__ for how this works.
 
 """
 
-from asynq import asynq, result
+from asynq import asynq
 
 
 called = {}
@@ -51,8 +51,7 @@ def test():
     def inner():
         instance = Child()
         yield instance.method.asynq()
-        result(None)
-        return
+        return None
 
     inner()
     assert called["Parent1"]

--- a/asynq/tests/test_performance.py
+++ b/asynq/tests/test_performance.py
@@ -14,7 +14,7 @@
 
 import gc
 
-from asynq import asynq, debug, result, AsyncTask
+from asynq import asynq, debug, AsyncTask
 from .helpers import Profiler
 
 values = {}  # type: ignore
@@ -35,8 +35,7 @@ def wrapped_async(*args, **kwargs):
 @asynq(pure=True)
 def get(key):
     global values
-    result(values.get(key))
-    return
+    return values.get(key)
     yield  # Must be a generator
 
 

--- a/asynq/tests/test_profiler.py
+++ b/asynq/tests/test_profiler.py
@@ -5,14 +5,14 @@ import collections
 
 from qcore import SECOND
 from qcore.asserts import assert_eq, assert_le, assert_ge, assert_unordered_list_eq
-from asynq import asynq, debug, profiler, result
+from asynq import asynq, debug, profiler
 from .debug_cache import reset_caches, mc
 from .caching import ExternalCacheBatchItem
 
 
 class ProfilerThread(threading.Thread):
     def __init__(self, stats_list):
-        threading.Thread.__init__(self)
+        super().__init__()
         self.stats_list = stats_list[:]
 
     def run(self):
@@ -55,8 +55,7 @@ def test_collect_perf_stats():
     @asynq()
     def func(depth):
         if depth == 0:
-            result((yield ExternalCacheBatchItem(mc._batch, "get", "test")))
-            return
+            return (yield ExternalCacheBatchItem(mc._batch, "get", "test"))
         time.sleep(float(sleep_time) / SECOND)
         yield func.asynq(depth - 1), func.asynq(depth - 1)
 

--- a/asynq/tests/test_recursion.py
+++ b/asynq/tests/test_recursion.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 from qcore.asserts import AssertRaises
-from six.moves import xrange
 
-from asynq import asynq, debug, result
+from asynq import asynq, debug
 from .helpers import Profiler
 
 
@@ -30,12 +29,10 @@ def test_recursion():
     @asynq()
     def sum_async(i, dump_progress=False):
         if i == 0:
-            result(0)
-            return
+            return 0
         if dump_progress and i % 100 == 0:
             print("... in sum_async(%s)" % i)
-        result(i + (yield sum_async.asynq(i - 1, dump_progress)))
-        return
+        return i + (yield sum_async.asynq(i - 1, dump_progress))
 
     with AssertRaises(RuntimeError):
         sum(2000, True)  # By default max stack depth is ~ 1000
@@ -46,19 +43,19 @@ def test_recursion():
 
     p1 = Profiler("200 x sum(500)")
     with p1:
-        for i in xrange(0, 200):
+        for i in range(200):
             sum(500)
 
     p2 = Profiler("20 x sum_async(500)() (w/assertions)")
     with p2:
-        for i in xrange(0, 20):
+        for i in range(20):
             sum_async(500)
 
     print("Slowdown: %s" % (p2.diff * 10.0 / p1.diff))
 
     p3 = Profiler("20 x sum_async(500)() (w/o assertions)")
     with debug.disable_complex_assertions(), p3:
-        for i in xrange(0, 20):
+        for i in range(0, 20):
             sum_async(500)
 
     print("Slowdown: %s" % (p3.diff * 10.0 / p1.diff))

--- a/asynq/tests/test_scoped_value.py
+++ b/asynq/tests/test_scoped_value.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from qcore.asserts import assert_eq
-from asynq import AsyncScopedValue, asynq, result, async_override
+from asynq import AsyncScopedValue, asynq, async_override
 from asynq.batching import DebugBatchItem
 
 v = AsyncScopedValue("a")
@@ -35,8 +35,7 @@ def async_scoped_value_helper(inner_val):
     with v.override(inner_val):
         yield DebugBatchItem()
         assert_eq(v.get(), inner_val)
-        result((yield nested.asynq()))
-        return
+        return (yield nested.asynq())
 
 
 @asynq()

--- a/asynq/tests/test_yield_result.py
+++ b/asynq/tests/test_yield_result.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from asynq import asynq
+from asynq import asynq, result
 from .helpers import Profiler
 
 counter = 0
@@ -41,7 +41,7 @@ def test():
         try:
             print("In try block.")
             yield incr()
-            return (yield incr())
+            result((yield incr()))
         except BaseException as e:
             print("In except block, e = " + repr(e))
             assert sync_incr() == 3

--- a/asynq/tests/test_yield_result.py
+++ b/asynq/tests/test_yield_result.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from asynq import asynq, result
+from asynq import asynq
 from .helpers import Profiler
 
 counter = 0
@@ -26,8 +26,7 @@ def test():
         global counter
         counter += 1
         print("Counter: %i" % counter)
-        result(counter)
-        return
+        return counter
         yield
 
     def sync_incr():
@@ -42,8 +41,7 @@ def test():
         try:
             print("In try block.")
             yield incr()
-            result((yield incr()))  # ; return
-            assert False, "Must not reach this point!"
+            return (yield incr())
         except BaseException as e:
             print("In except block, e = " + repr(e))
             assert sync_incr() == 3

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__doc__ = """
+"""
 
 Examples of how to use asynq.
 

--- a/examples/batching.py
+++ b/examples/batching.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__doc__ = """
+"""
 
 Simple example of asynq-based batching support for a memcache client.
 
@@ -20,12 +20,12 @@ Requires the python-memcached library to be installed.
 
 """
 
-from asynq import asynq, async_proxy, BatchBase, BatchItemBase, result
+from asynq import asynq, async_proxy, BatchBase, BatchItemBase
 import qcore
 import itertools
 import memcache
 
-MISS = qcore.MarkerObject(u"miss")
+MISS = qcore.MarkerObject("miss")
 
 
 class Client(object):
@@ -48,7 +48,7 @@ class Client(object):
             "Returns names of authors for all of the given aids."
             uids = yield [author_of_answer.asynq(aid) for aid in aids]
             names = yield [name_of_user.asynq(uid) for uid in uids]
-            result(names); return
+            return names
 
     """
 
@@ -104,8 +104,7 @@ class Client(object):
                     # there is a race condition here since somebody else could have set the key
                     # while we were computing the value, but don't worry about that for now
                     yield self.set.asynq(key, value)
-                result(value)
-                return
+                return value
 
             return wrapped
 
@@ -115,7 +114,7 @@ class Client(object):
 class _MCBatch(BatchBase):
     def __init__(self, client):
         self.client = client
-        super(_MCBatch, self).__init__()
+        super().__init__()
 
     def _try_switch_active_batch(self):
         if self.client.batch is self:
@@ -143,6 +142,6 @@ class _MCBatch(BatchBase):
 
 class _MCBatchItem(BatchItemBase):
     def __init__(self, batch, cmd, args):
-        super(_MCBatchItem, self).__init__(batch)
+        super().__init__(batch)
         self.cmd = cmd
         self.args = args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,6 @@ exclude = '''
   | \.mypy_cache
   | \.tox
   | \.venv
+  | \.eggs
 )/
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.black]
+target_version = ['py36', 'py37', 'py38', 'py39']
+include = '\.pyi?$'
+skip-magic-trailing-comma = true
+experimental-string-processing = true
+
+exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+)/
+'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 nose==1.3.7
-six==1.15.0
-mock; python_version < "3.3"
 Cython>=0.27.1
 qcore
-inspect2
 pygments
 black==21.6b0; python_version >= "3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Cython>=0.27.1
 qcore
 pygments
 black==21.6b0; python_version >= "3.6"
+mypy==0.910

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ from setuptools.extension import Extension
 import glob
 import os.path
 import codecs
-import sys
 
 
 CYTHON_MODULES = [
@@ -66,22 +65,15 @@ if __name__ == "__main__":
         classifiers=[
             "License :: OSI Approved :: Apache Software License",
             "Programming Language :: Python",
-            "Programming Language :: Python :: 2.7",
-            "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
         ],
         keywords="quora asynq common utility",
         packages=["asynq", "asynq.tests"],
         package_data={"asynq": DATA_FILES},
         ext_modules=EXTENSIONS,
         setup_requires=["Cython>=0.27.1", "qcore", "setuptools"],
-        install_requires=[
-            "Cython>=0.27.1",
-            "qcore",
-            "inspect2",
-            'mock; python_version < "3.3"',
-            "pygments",
-        ],
+        install_requires=["Cython>=0.27.1", "qcore", "pygments"],
     )

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     -rrequirements.txt
 
 commands =
-    mypy qcore
+    mypy asynq
 
 [testenv:black]
 commands =


### PR DESCRIPTION
Finally doing away with Python 2.7 and `result(); return`