### PR TITLE
pin Cython for setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,6 @@ if __name__ == "__main__":
         packages=["asynq", "asynq.tests"],
         package_data={"asynq": DATA_FILES},
         ext_modules=EXTENSIONS,
-        setup_requires=["Cython>=0.27.1", "qcore", "setuptools"],
+        setup_requires=["Cython==0.29.36", "qcore", "setuptools"],
         install_requires=["Cython>=0.27.1", "qcore", "pygments"],
     )


### PR DESCRIPTION
Cython==3.0.0 has backwards incompatible changes that break setup