### PR TITLE
Fix async_proxy + .asyncio()

### DIFF
--- a/asynq/decorators.py
+++ b/asynq/decorators.py
@@ -253,6 +253,9 @@ class AsyncProxyDecorator(AsyncDecorator):
         AsyncDecorator.__init__(self, fn, None, asyncio_fn=asyncio_fn)
 
     def _call_pure(self, args, kwargs):
+        if asynq_to_async.is_asyncio_mode():
+            return self.asyncio(*args, **kwargs)
+
         return self.fn(*args, **kwargs)
 
 


### PR DESCRIPTION
.asyncio() logic in `PureAsyncDecorator._call_pure` was shadowed by `AsyncProxyDecorator._call_pure`.
