### PR TITLE
Make the behavior consistent for asyncio and asynq: raised error.

### DIFF
--- a/asynq/asynq_to_async.py
+++ b/asynq/asynq_to_async.py
@@ -31,8 +31,8 @@ async def _gather(awaitables):
     """Gather awaitables, but wait all other awaitables to finish even if some of them fail."""
 
     tasks = [asyncio.ensure_future(awaitable) for awaitable in awaitables]
-    done, _ = await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
-    return [task.result() for task in done]
+    await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
+    return [task.result() for task in tasks]
 
 
 async def resolve_awaitables(x: Any):

--- a/asynq/asynq_to_async.py
+++ b/asynq/asynq_to_async.py
@@ -31,7 +31,14 @@ async def _gather(awaitables):
     """Gather awaitables, but wait all other awaitables to finish even if some of them fail."""
 
     tasks = [asyncio.ensure_future(awaitable) for awaitable in awaitables]
+
+    # Wait for all tasks to finish, even if some of them fail.
     await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
+
+    # mark exceptions are retrieved.
+    for task in tasks:
+        task.exception()
+
     return [task.result() for task in tasks]
 
 

--- a/asynq/decorators.py
+++ b/asynq/decorators.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import inspect
-import sys
 from typing import Any, Coroutine
 
 import qcore.decorators
@@ -164,7 +163,6 @@ class PureAsyncDecorator(qcore.decorators.DecoratorBase):
                                 send = await asynq_to_async.resolve_awaitables(result)
                                 exception = None
                             except Exception as exc:
-                                traceback = sys.exc_info()[2]
                                 exception = exc
 
                 self.asyncio_fn = wrapped

--- a/asynq/tests/test_asynq_to_async.py
+++ b/asynq/tests/test_asynq_to_async.py
@@ -14,6 +14,7 @@
 
 
 import asyncio
+import pytest
 import time
 
 from qcore.asserts import assert_eq
@@ -49,6 +50,26 @@ def test_asyncio():
         return obj
 
     assert asyncio.run(g.asyncio(5)) == {"a": [1, 2], "b": (3, 4), "c": 5, "d": 200}
+
+
+def test_asyncio_exception():
+    async def f2_async():
+        assert False
+
+    @asynq.asynq(asyncio_fn=f2_async)
+    def f2():
+        assert False
+
+    @asynq.asynq()
+    def f3():
+        yield f2.asynq()
+
+    @asynq.asynq()
+    def f():
+        with pytest.raises(AssertionError):
+            yield [f3.asynq(), f3.asynq()]
+
+    asyncio.run(f.asyncio())
 
 
 def test_context():


### PR DESCRIPTION
This PR addressed two behaviors:
- Propagates raised errors to the caller so that the caller can catch the exception.
- If an asynq function yields a sequence of tasks, cancels all other tasks if any of them fail.
