### PR TITLE
asynq_to_async: handle edge case - empty list of tasks

### DIFF
--- a/asynq/asynq_to_async.py
+++ b/asynq/asynq_to_async.py
@@ -30,6 +30,9 @@ def is_asyncio_mode():
 async def _gather(awaitables):
     """Gather awaitables, but wait all other awaitables to finish even if some of them fail."""
 
+    if len(awaitables) == 0:
+        return []
+
     tasks = [asyncio.ensure_future(awaitable) for awaitable in awaitables]
 
     # Wait for all tasks to finish, even if some of them fail.

--- a/asynq/tests/test_asynq_to_async.py
+++ b/asynq/tests/test_asynq_to_async.py
@@ -51,6 +51,12 @@ def test_asyncio():
 
     assert asyncio.run(g.asyncio(5)) == {"a": [1, 2], "b": (3, 4), "c": 5, "d": 200}
 
+    @asynq.asynq()
+    def empty():
+        return (yield [])
+
+    assert asyncio.run(empty.asyncio()) == []
+
 
 def test_asyncio_exception():
     call_count = 0


### PR DESCRIPTION
Previously, I replaced `asyncio.gather` with `asyncio.wait`. However `asyncio.wait` throws an error when provided with an  empty list of tasks whereas `asyncio.gather` doesn't. 

Fix that case and added a test case.