### PR TITLE
Fix leave_context_asyncio to handle cancelled asyncio task

### DIFF
--- a/asynq/contexts.py
+++ b/asynq/contexts.py
@@ -93,7 +93,7 @@ def leave_context_asyncio(context):
         debug.write("@async: -context: %s" % debug.str(context))
 
     task = asyncio.current_task()
-    del getattr(task, ASYNCIO_CONTEXT_FIELD)[id(context)]  # type: ignore
+    getattr(task, ASYNCIO_CONTEXT_FIELD, {}).pop(id(context), None)  # type: ignore
 
 
 def pause_contexts_asyncio(task):
@@ -104,7 +104,7 @@ def pause_contexts_asyncio(task):
 
 
 def resume_contexts_asyncio(task):
-    if not getattr(task, ASYNCIO_CONTEXT_ACTIVE_FIELD, False):
+    if not getattr(task, ASYNCIO_CONTEXT_ACTIVE_FIELD, True):
         setattr(task, ASYNCIO_CONTEXT_ACTIVE_FIELD, True)
         for ctx in getattr(task, ASYNCIO_CONTEXT_FIELD, {}).values():
             ctx.resume()

--- a/asynq/contexts.py
+++ b/asynq/contexts.py
@@ -92,7 +92,9 @@ class AsyncContext(object):
         return self
 
     def __exit__(self, ty, value, tb):
-        if not is_asyncio_mode():
+        if is_asyncio_mode():
+            self.pause()
+        else:
             leave_context(self, self._active_task)
             self.pause()
             del self._active_task

--- a/asynq/contexts.py
+++ b/asynq/contexts.py
@@ -67,7 +67,6 @@ def leave_context(context, active_task):
         active_task._leave_context(context)
 
 
-
 class AsyncContext(object):
     """Base class for contexts that should pause and resume during an async's function execution.
 

--- a/asynq/decorators.py
+++ b/asynq/decorators.py
@@ -23,7 +23,6 @@ import qcore.inspection as core_inspection
 
 from . import async_task, futures
 from .asynq_to_async import AsyncioMode, is_asyncio_mode, resolve_awaitables
-from .contexts import pause_contexts_asyncio, resume_contexts_asyncio
 
 __traceback_hide__ = True
 
@@ -114,7 +113,6 @@ def convert_asynq_to_async(fn):
 
                 generator = fn(*_args, **_kwargs)
                 while True:
-                    resume_contexts_asyncio(task)
                     try:
                         if exception is None:
                             result = generator.send(send)
@@ -125,7 +123,6 @@ def convert_asynq_to_async(fn):
                     except StopIteration as exc:
                         return exc.value
 
-                    pause_contexts_asyncio(task)
                     try:
                         send = await resolve_awaitables(result)
                         exception = None

--- a/asynq/tests/test_asynq_to_async.py
+++ b/asynq/tests/test_asynq_to_async.py
@@ -105,7 +105,7 @@ def test_context():
         await asyncio.sleep(0.1)
 
     @asynq.asynq()
-    def f1():
+    def f1():  # 500ms
         with AsyncTimer() as timer:
             time.sleep(0.1)
             t1, t2 = yield f2.asynq()
@@ -113,7 +113,7 @@ def test_context():
         return timer.total_time, t1, t2
 
     @asynq.asynq()
-    def f2():
+    def f2():  # 300ms
         with AsyncTimer() as timer:
             time.sleep(0.1)
             t = yield f3.asynq()
@@ -121,7 +121,7 @@ def test_context():
         return timer.total_time, t
 
     @asynq.asynq()
-    def f3():
+    def f3():  # 100ms
         with AsyncTimer() as timer:
             # since AsyncTimer is paused on blocking operations,
             # the time for TestBatch is not measured
@@ -129,9 +129,9 @@ def test_context():
         return timer.total_time
 
     t1, t2, t3 = asyncio.run(f1.asyncio())
-    assert_eq(400000, t1, tolerance=10000)  # 400ms, 10us tolerance
-    assert_eq(200000, t2, tolerance=10000)  # 200ms, 10us tolerance
-    assert_eq(000000, t3, tolerance=10000)  #   0ms, 10us tolerance
+    assert_eq(500000, t1, tolerance=10000)  # 400ms, 10us tolerance
+    assert_eq(300000, t2, tolerance=10000)  # 200ms, 10us tolerance
+    assert_eq(100000, t3, tolerance=10000)  #   0ms, 10us tolerance
 
 
 def test_method():

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ qcore
 pygments
 black==24.3.0
 mypy==1.4.1
+typing_extensions==4.11.0


### PR DESCRIPTION
Fix the error '_asyncio.Task' object has no attribute '_asynq_contexts' when a task is cancelled.
