### PR TITLE
Update CI OS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-11]
+        os: [ubuntu-20.04, windows-2022, macOS-13]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/
macos-11 is deprecated and macos-12 reaches EOL in 2 months